### PR TITLE
Add a `$path` field.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,5 +2,8 @@
 
 All Notable changes to `LaravelMP3` will be documented in this file
 
+## 2018-01-02
+- When loading compare the `path` field to the passed in `$path` and reanalyse if different
+
 ## 2016-08-30
 - Initial release

--- a/src/LaravelMP3.php
+++ b/src/LaravelMP3.php
@@ -6,15 +6,16 @@ class LaravelMP3
 {
 
     private $info;
+    private $path;
 
     public function load($path = null)
     {
-        if ($this->info === null) {
+        if ($path !== $this->path || $this->info === null) {
             //using include causes redeclaration exception, while using this class to process more than one file (eg. in a loop on all mp3s)
             include_once('getid3/getid3.php');
             $getID3 = new \getID3;
             $this->info = $getID3->analyze( $path );
-
+            $this->path = $path;
         }
         return $this->info;
     }


### PR DESCRIPTION
When loading an MP3 file, check if the path appears to be the same; if
not, reanalyse the file.